### PR TITLE
Add configuration and modify the default github file download link #94

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,8 @@ import (
 	"net"
 	"net/netip"
 	"net/url"
+	"os"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -16,6 +18,7 @@ import (
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/option"
 	dns "github.com/sagernet/sing-dns"
+	"github.com/sagernet/sing/common/auth"
 )
 
 const (
@@ -38,6 +41,30 @@ const (
 	InboundMixedTag = "mixed-in"
 	InboundDNSTag   = "dns-in"
 )
+
+func ReplaceEnvVariables(input string) string {
+	re := regexp.MustCompile(`\$\{(\w+)\}`)
+	return re.ReplaceAllStringFunc(input, func(m string) string {
+		varName := m[2 : len(m)-1]
+		return os.Getenv(varName)
+	})
+}
+
+func GetUsers() []auth.User {
+	username := os.Getenv("PROXY_USER")
+	password := os.Getenv("PROXY_PASS")
+
+	if username == "" || password == "" {
+		return []auth.User{}
+	}
+
+	return []auth.User{
+		{
+			Username: username,
+			Password: password,
+		},
+	}
+}
 
 var OutboundMainProxyTag = OutboundSelectTag
 
@@ -274,7 +301,7 @@ func setClashAPI(options *option.Options, opt *HiddifyOptions) {
 			ClashAPI: &option.ClashAPIOptions{
 				ExternalController: fmt.Sprintf("%s:%d", "127.0.0.1", opt.ClashApiPort),
 				Secret:             opt.ClashApiSecret,
-				ExternalUI:         opt.ClashWebPath,
+				ExternalUI:         ReplaceEnvVariables(opt.ClashWebPath),
 			},
 			CacheFile: &option.CacheFileOptions{
 				Enabled: false,
@@ -365,6 +392,7 @@ func setInbound(options *option.Options, opt *HiddifyOptions) {
 						DomainStrategy:           inboundDomainStrategy,
 					},
 				},
+				Users:          GetUsers(),
 				SetSystemProxy: opt.SetSystemProxy,
 			},
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -594,7 +594,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-ads",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-category-ads-all.srs",
+				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-category-ads-all.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -603,7 +603,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-malware",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-malware.srs",
+				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-malware.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -612,7 +612,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-phishing",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-phishing.srs",
+				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-phishing.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -621,7 +621,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-cryptominers",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-cryptominers.srs",
+				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-cryptominers.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -630,7 +630,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geoip-phishing",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-phishing.srs",
+				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-phishing.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -639,7 +639,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geoip-malware",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-malware.srs",
+				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-malware.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -697,7 +697,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geoip-" + opt.Region,
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geoip-" + opt.Region + ".srs",
+				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geoip-" + opt.Region + ".srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -706,7 +706,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-" + opt.Region,
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geosite-" + opt.Region + ".srs",
+				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geosite-" + opt.Region + ".srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})

--- a/config/config.go
+++ b/config/config.go
@@ -296,6 +296,8 @@ func setClashAPI(options *option.Options, opt *HiddifyOptions) {
 	if opt.EnableClashApi {
 		if opt.ClashApiSecret == "" {
 			opt.ClashApiSecret = generateRandomString(16)
+		} else {
+			opt.ClashApiSecret = ReplaceEnvVariables(opt.ClashApiSecret)
 		}
 		options.Experimental = &option.ExperimentalOptions{
 			ClashAPI: &option.ClashAPIOptions{

--- a/config/config.go
+++ b/config/config.go
@@ -277,7 +277,7 @@ func setClashAPI(options *option.Options, opt *HiddifyOptions) {
 			},
 
 			CacheFile: &option.CacheFileOptions{
-				Enabled: true,
+				Enabled: false,
 				Path:    "clash.db",
 			},
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -594,7 +594,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-ads",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-category-ads-all.srs",
+				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-category-ads-all.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -603,7 +603,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-malware",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-malware.srs",
+				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-malware.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -612,7 +612,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-phishing",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-phishing.srs",
+				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-phishing.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -621,7 +621,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-cryptominers",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-cryptominers.srs",
+				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-cryptominers.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -630,7 +630,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geoip-phishing",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-phishing.srs",
+				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-phishing.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -639,7 +639,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geoip-malware",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-malware.srs",
+				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-malware.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -697,7 +697,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geoip-" + opt.Region,
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geoip-" + opt.Region + ".srs",
+				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geoip-" + opt.Region + ".srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -706,7 +706,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-" + opt.Region,
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh-proxy.com/raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geosite-" + opt.Region + ".srs",
+				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geosite-" + opt.Region + ".srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})

--- a/config/config.go
+++ b/config/config.go
@@ -50,20 +50,19 @@ func ReplaceEnvVariables(input string) string {
 	})
 }
 
-func GetUsers() []auth.User {
-	username := os.Getenv("PROXY_USER")
-	password := os.Getenv("PROXY_PASS")
-
-	if username == "" || password == "" {
-		return []auth.User{}
+func GetUsers(opt *HiddifyOptions) []auth.User {
+	var newUsers []auth.User
+	for _, user := range opt.InboundOptions.Users {
+		newUsername := ReplaceEnvVariables(user.Username)
+		newPassword := ReplaceEnvVariables(user.Password)
+		if newUsername != "" && newPassword != "" {
+			newUsers = append(newUsers, auth.User{
+				Username: newUsername,
+				Password: newPassword,
+			})
+		}
 	}
-
-	return []auth.User{
-		{
-			Username: username,
-			Password: password,
-		},
-	}
+	return newUsers
 }
 
 var OutboundMainProxyTag = OutboundSelectTag
@@ -394,7 +393,7 @@ func setInbound(options *option.Options, opt *HiddifyOptions) {
 						DomainStrategy:           inboundDomainStrategy,
 					},
 				},
-				Users:          GetUsers(),
+				Users:          GetUsers(opt),
 				SetSystemProxy: opt.SetSystemProxy,
 			},
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -623,7 +623,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-ads",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-category-ads-all.srs",
+				URL:            opt.GeositeConfigOptions.GeositeAds,
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -632,7 +632,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-malware",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-malware.srs",
+				URL:            opt.GeositeConfigOptions.GeositeMalware,
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -641,7 +641,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-phishing",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-phishing.srs",
+				URL:            opt.GeositeConfigOptions.GeositePhishing,
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -650,7 +650,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-cryptominers",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-cryptominers.srs",
+				URL:            opt.GeositeConfigOptions.GeositeCryptominers,
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -659,7 +659,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geoip-phishing",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-phishing.srs",
+				URL:            opt.GeositeConfigOptions.GeoipPhishing,
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -668,7 +668,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geoip-malware",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-malware.srs",
+				URL:            opt.GeositeConfigOptions.GeoipMalware,
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -701,6 +701,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 		})
 
 	}
+	opt.Region = ReplaceEnvVariables(opt.Region)
 	if opt.Region != "other" {
 		dnsRules = append(dnsRules, option.DefaultDNSRule{
 			DomainSuffix: []string{"." + opt.Region},
@@ -726,7 +727,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geoip-" + opt.Region,
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geoip-" + opt.Region + ".srs",
+				URL:            ReplaceEnvVariables(opt.GeositeConfigOptions.GeoipRegion),
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -735,7 +736,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-" + opt.Region,
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://gh.api.99988866.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geosite-" + opt.Region + ".srs",
+				URL:            ReplaceEnvVariables(opt.GeositeConfigOptions.GeositeRegion),
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})

--- a/config/config.go
+++ b/config/config.go
@@ -594,7 +594,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-ads",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-category-ads-all.srs",
+				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-category-ads-all.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -603,7 +603,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-malware",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-malware.srs",
+				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-malware.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -612,7 +612,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-phishing",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-phishing.srs",
+				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-phishing.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -621,7 +621,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-cryptominers",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-cryptominers.srs",
+				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geosite-cryptominers.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -630,7 +630,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geoip-phishing",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-phishing.srs",
+				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-phishing.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -639,7 +639,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geoip-malware",
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-malware.srs",
+				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/block/geoip-malware.srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -697,7 +697,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geoip-" + opt.Region,
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geoip-" + opt.Region + ".srs",
+				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geoip-" + opt.Region + ".srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})
@@ -706,7 +706,7 @@ func setRoutingOptions(options *option.Options, opt *HiddifyOptions) {
 			Tag:    "geosite-" + opt.Region,
 			Format: C.RuleSetFormatBinary,
 			RemoteOptions: option.RemoteRuleSet{
-				URL:            "https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geosite-" + opt.Region + ".srs",
+				URL:            "https://ghgo.xyz/https://raw.githubusercontent.com/hiddify/hiddify-geo/rule-set/country/geosite-" + opt.Region + ".srs",
 				UpdateInterval: option.Duration(5 * time.Hour * 24),
 			},
 		})

--- a/config/config.go
+++ b/config/config.go
@@ -274,8 +274,8 @@ func setClashAPI(options *option.Options, opt *HiddifyOptions) {
 			ClashAPI: &option.ClashAPIOptions{
 				ExternalController: fmt.Sprintf("%s:%d", "127.0.0.1", opt.ClashApiPort),
 				Secret:             opt.ClashApiSecret,
+				ExternalUI:         opt.ClashWebPath,
 			},
-
 			CacheFile: &option.CacheFileOptions{
 				Enabled: false,
 				Path:    "clash.db",

--- a/config/hiddify_option.go
+++ b/config/hiddify_option.go
@@ -28,6 +28,19 @@ type HiddifyOptions struct {
 	InboundOptions
 	URLTestOptions
 	RouteOptions
+	GeositeConfigOptions
+}
+
+// Move the download link to the configuration file
+type GeositeConfigOptions struct {
+	GeositeAds          string `json:"geosite-ads"`
+	GeositeMalware      string `json:"geosite-malware"`
+	GeositePhishing     string `json:"geosite-phishing"`
+	GeositeCryptominers string `json:"geosite-cryptominers"`
+	GeoipPhishing       string `json:"geoip-phishing"`
+	GeoipMalware        string `json:"geoip-malware"`
+	GeoipRegion         string `json:"geoip-region"`
+	GeositeRegion       string `json:"geosite-region"`
 }
 
 type DNSOptions struct {

--- a/config/hiddify_option.go
+++ b/config/hiddify_option.go
@@ -11,6 +11,7 @@ type HiddifyOptions struct {
 	LogFile                 string `json:"log-file"`
 	EnableClashApi          bool   `json:"enable-clash-api"`
 	ClashApiPort            uint16 `json:"clash-api-port"`
+	ClashWebPath            string `json:"clash-web-path"`
 	ClashApiSecret          string `json:"web-secret"`
 	Region                  string `json:"region"`
 	BlockAds                bool   `json:"block-ads"`

--- a/config/hiddify_option.go
+++ b/config/hiddify_option.go
@@ -3,6 +3,7 @@ package config
 import (
 	"github.com/sagernet/sing-box/option"
 	dns "github.com/sagernet/sing-dns"
+	"github.com/sagernet/sing/common/auth"
 )
 
 type HiddifyOptions struct {
@@ -40,15 +41,16 @@ type DNSOptions struct {
 }
 
 type InboundOptions struct {
-	EnableTun        bool   `json:"enable-tun"`
-	EnableTunService bool   `json:"enable-tun-service"`
-	SetSystemProxy   bool   `json:"set-system-proxy"`
-	MixedPort        uint16 `json:"mixed-port"`
-	TProxyPort       uint16 `json:"tproxy-port"`
-	LocalDnsPort     uint16 `json:"local-dns-port"`
-	MTU              uint32 `json:"mtu"`
-	StrictRoute      bool   `json:"strict-route"`
-	TUNStack         string `json:"tun-implementation"`
+	EnableTun        bool        `json:"enable-tun"`
+	EnableTunService bool        `json:"enable-tun-service"`
+	SetSystemProxy   bool        `json:"set-system-proxy"`
+	MixedPort        uint16      `json:"mixed-port"`
+	TProxyPort       uint16      `json:"tproxy-port"`
+	LocalDnsPort     uint16      `json:"local-dns-port"`
+	MTU              uint32      `json:"mtu"`
+	StrictRoute      bool        `json:"strict-route"`
+	TUNStack         string      `json:"tun-implementation"`
+	Users            []auth.User `json:"users,omitempty"`
 }
 
 type URLTestOptions struct {

--- a/v2/standalone.go
+++ b/v2/standalone.go
@@ -167,7 +167,7 @@ func buildConfig(configContent string, options config.HiddifyOptions) (string, e
 	}
 
 	finalconfig.Log.Output = ""
-	finalconfig.Experimental.ClashAPI.ExternalUI = "/etc/s6-overlay/s6-rc.d/hiddify/webui"
+	// finalconfig.Experimental.ClashAPI.ExternalUI = "/etc/s6-overlay/s6-rc.d/hiddify/webui"
 	if options.AllowConnectionFromLAN {
 		finalconfig.Experimental.ClashAPI.ExternalController = "0.0.0.0:6756"
 	} else {

--- a/v2/standalone.go
+++ b/v2/standalone.go
@@ -167,7 +167,7 @@ func buildConfig(configContent string, options config.HiddifyOptions) (string, e
 	}
 
 	finalconfig.Log.Output = ""
-	finalconfig.Experimental.ClashAPI.ExternalUI = "webui"
+	finalconfig.Experimental.ClashAPI.ExternalUI = "/etc/s6-overlay/s6-rc.d/hiddify/webui"
 	if options.AllowConnectionFromLAN {
 		finalconfig.Experimental.ClashAPI.ExternalController = "0.0.0.0:6756"
 	} else {


### PR DESCRIPTION
Add configuration and modify the default github file download link #94
the current Caddy core can be run in Docker, which is very convenient for people who only have the airport address.