### PR TITLE
add CI for arm64 Linux build for main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,8 @@ jobs:
           - { name: 'hiddify-core-android', os: 'ubuntu-latest', target: 'android' }
           - { name: 'hiddify-core-linux-amd64', os: 'ubuntu-22.04', target: 'linux-amd64' }
           - { name: "hiddify-core-windows-amd64", os: 'ubuntu-latest', target: 'windows-amd64', aarch: 'x64' }
-          - { name: "hiddify-core-macos-universal", os: 'macos-12', target: 'macos-universal' }
-          - { name: "hiddify-core-ios", os: "macos-12", target: "ios" }
+          - { name: "hiddify-core-macos-universal", os: 'macos-13', target: 'macos-universal' }
+          - { name: "hiddify-core-ios", os: "macos-13", target: "ios" }
           # linux custom
           - {name: hiddify-cli-linux-amd64, goos: linux, goarch: amd64, goamd64: v1, target: 'linux-custom', os: 'ubuntu-22.04'}
           - {name: hiddify-cli-linux-amd64-v3, goos: linux, goarch: amd64, goamd64: v3, target: 'linux-custom', os: 'ubuntu-22.04'}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,25 +43,25 @@ jobs:
       matrix:
         job:
           - { name: 'hiddify-core-android', os: 'ubuntu-latest', target: 'android' }
-          - { name: 'hiddify-core-linux-amd64', os: 'ubuntu-20.04', target: 'linux-amd64' }
+          - { name: 'hiddify-core-linux-amd64', os: 'ubuntu-22.04', target: 'linux-amd64' }
           - { name: "hiddify-core-windows-amd64", os: 'ubuntu-latest', target: 'windows-amd64', aarch: 'x64' }
           - { name: "hiddify-core-macos-universal", os: 'macos-12', target: 'macos-universal' }
           - { name: "hiddify-core-ios", os: "macos-12", target: "ios" }
           # linux custom
-          - {name: hiddify-cli-linux-amd64, goos: linux, goarch: amd64, goamd64: v1, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-amd64-v3, goos: linux, goarch: amd64, goamd64: v3, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-386, goos: linux, goarch: 386, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-arm64, goos: linux, goarch: arm64, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-armv5, goos: linux, goarch: arm, goarm: 5, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-armv6, goos: linux, goarch: arm, goarm: 6, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-armv7, goos: linux, goarch: arm, goarm: 7, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-mips-softfloat, goos: linux, goarch: mips, gomips: softfloat, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-mips-hardfloat, goos: linux, goarch: mips, gomips: hardfloat, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-mipsel-softfloat, goos: linux, goarch: mipsle, gomips: softfloat, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-mipsel-hardfloat, goos: linux, goarch: mipsle, gomips: hardfloat, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-mips64, goos: linux, goarch: mips64, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-mips64el, goos: linux, goarch: mips64le, target: 'linux-custom', os: 'ubuntu-20.04'}
-          - {name: hiddify-cli-linux-s390x, goos: linux, goarch: s390x, target: 'linux-custom', os: 'ubuntu-20.04'}
+          - {name: hiddify-cli-linux-amd64, goos: linux, goarch: amd64, goamd64: v1, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-amd64-v3, goos: linux, goarch: amd64, goamd64: v3, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-386, goos: linux, goarch: 386, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-arm64, goos: linux, goarch: arm64, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-armv5, goos: linux, goarch: arm, goarm: 5, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-armv6, goos: linux, goarch: arm, goarm: 6, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-armv7, goos: linux, goarch: arm, goarm: 7, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-mips-softfloat, goos: linux, goarch: mips, gomips: softfloat, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-mips-hardfloat, goos: linux, goarch: mips, gomips: hardfloat, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-mipsel-softfloat, goos: linux, goarch: mipsle, gomips: softfloat, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-mipsel-hardfloat, goos: linux, goarch: mipsle, gomips: hardfloat, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-mips64, goos: linux, goarch: mips64, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-mips64el, goos: linux, goarch: mips64le, target: 'linux-custom', os: 'ubuntu-22.04'}
+          - {name: hiddify-cli-linux-s390x, goos: linux, goarch: s390x, target: 'linux-custom', os: 'ubuntu-22.04'}
     
     runs-on: ${{ matrix.job.os }}
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
         job:
           - { name: 'hiddify-core-android', os: 'ubuntu-latest', target: 'android' }
           - { name: 'hiddify-core-linux-amd64', os: 'ubuntu-22.04', target: 'linux-amd64' }
+          - { name: 'hiddify-core-linux-arm64', os: 'ubuntu-22.04-arm', target: 'linux-arm64' }
           - { name: "hiddify-core-windows-amd64", os: 'ubuntu-latest', target: 'windows-amd64', aarch: 'x64' }
           - { name: "hiddify-core-macos-universal", os: 'macos-13', target: 'macos-universal' }
           - { name: "hiddify-core-ios", os: "macos-13", target: "ios" }

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -9,19 +9,11 @@ Additional Permissions and Restrictions Under GNU GPL Version 3 Section 7
 
 - Any forks should be published open-source under the same license.
 
-- Prior consent is required to publish a fork or utilize any part of this repository (github.com/hiddify/hiddify-next and github.com/hiddify/hiddify-next-core) in an application intended for publication on the App Store or for iOS/macOS platforms. (We reserve the right to modify this requirement in the future after completing development for iOS and macOS).
-- You need prior consent to publish a fork or use any part of this code in an application published in AppStore or publish for iOS or macOS. (We reserve the right to modify this requirement in the future after completing development for iOS and macOS).
-- You are free to:
-  - Share — copy and redistribute the material in any medium or format with 
-  - Adapt — remix, transform, and build upon the material
-- Under the following terms:
-  - Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+— You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
 
-  - NonCommercial — You may not use the material for commercial purposes. You can not even include ads in it.
+- NonCommercial — You may not use the material for commercial purposes. You can not even include ads in it.
   
-  - ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
- 
-  - Prior consent is required before utilizing any portion of this code for integration into an application intended for the App Store.
+- ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
 
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,15 @@ linux-amd64:
 	rm -rf ./lib
 	chmod +x $(BINDIR)/$(CLINAME)
 	make webui
+linux-arm64:
+	mkdir -p $(BINDIR)/lib
+	env GOOS=linux GOARCH=arm64 $(GOBUILDLIB) -o $(BINDIR)/lib/$(LIBNAME).so ./custom
+	mkdir lib
+	cp $(BINDIR)/lib/$(LIBNAME).so ./lib/$(LIBNAME).so
+	env GOOS=linux GOARCH=arm64  CGO_LDFLAGS="./lib/$(LIBNAME).so" $(GOBUILDSRV) -o $(BINDIR)/$(CLINAME) ./cli/bydll
+	rm -rf ./lib
+	chmod +x $(BINDIR)/$(CLINAME)
+	make webui
 
 
 linux-custom:


### PR DESCRIPTION
I was hoping that [hiddify-app](https://github.com/hiddify/hiddify-app) already support changes, that was made hiddify-core in v3 branch. For example:
[rename libcore to hiddify-core](https://github.com/hiddify/hiddify-core/commit/a0e09ea208f7ba3a7917921dc509042e4b115629) or [move custom.go and replace setupOnce function](https://github.com/hiddify/hiddify-core/commit/0a7eb695f118a3df7da8f4eaf95690ac32546482)

But hiddify-app is not ready for that. That's why I added arm64 Linux support to hiddify-core's main branch, then added fix to hiddify-app and got working VPN on my rk3588 SBC:
```
user@rock-5b:~$ uname -a
Linux rock-5b 6.14.0-rc4-edge-rockchip64 #1 SMP PREEMPT Sun Feb 23 20:32:57 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux
user@rock-5b:~$ which hiddify 
/usr/bin/hiddify
user@rock-5b:~$ file /usr/bin/hiddify
/usr/bin/hiddify: symbolic link to /usr/share/hiddify/hiddify
user@rock-5b:~$ file /usr/share/hiddify/hiddify
/usr/share/hiddify/hiddify: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=0b28d5e98323e1151526bac46fe7655295ef23c5, for GNU/Linux 3.7.0, not stripped

```
Here is 1st version of CI with arm64 Linux support in hiddify-core and hiddify-app:
https://github.com/q4a/hiddify-app/actions/runs/14672948667/job/41183552766
I temporarily disabled the rpm and AppImage build:
I will need to add fix for arm64 rpm build:
https://github.com/fastforgedev/fastforge/pull/204/files
And fix/workaround for arm64 AppImage:
https://github.com/fastforgedev/fastforge/issues/188#issuecomment-2201908384
to the repository: https://github.com/hiddify/flutter_distributor