### PR TITLE
fix(v2/hcore): prevent panic in StartService when HiddifyOptions is nil

### DIFF
--- a/v2/hcore/start.go
+++ b/v2/hcore/start.go
@@ -2,6 +2,7 @@ package hcore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -98,6 +99,14 @@ func StartService(ctx context.Context, in *StartRequest) (coreResponse *CoreInfo
 	}
 
 	static.previousStartRequest = in
+
+	if static.HiddifyOptions == nil {
+		return errorWrapper(
+			MessageType_ERROR_BUILDING_CONFIG,
+			errors.New("HiddifyOptions not initialized"),
+		)
+	}
+
 	options, err := BuildConfig(ctx, in)
 	if err != nil {
 		return errorWrapper(MessageType_ERROR_BUILDING_CONFIG, err)

--- a/v2/hcore/start_test.go
+++ b/v2/hcore/start_test.go
@@ -1,0 +1,20 @@
+package hcore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildConfig_StartServicePanic(t *testing.T) {
+	ctx := context.Background()
+
+	in := &StartRequest{
+		ConfigContent: "{}",
+	}
+
+	_, err := StartService(ctx, in)
+	require.Error(t, err)
+	require.Equal(t, static.CoreState, CoreStates_STOPPED)
+}


### PR DESCRIPTION
### Problem

`StartService` may panic when `static.HiddifyOptions` is nil.

```go
startmobile panic: runtime error:
invalid memory address or nil pointer dereference goroutine 15 [running]: runtime/debug.Stack()
runtime/debug/stack.go:26 +0x64
github.com/hiddify/hiddify-core/v2/
config. DeferPanicToError ({0x105bb e11f, Oxb}, 0x13006b818)
github.com/hiddify/hiddify-core/v2/
config/debug.go:30 +0x44
panic ({0x106181620?, 0x107609ba0?})
runtime/panic.go:783 +0x120
github.com/hiddify/hiddify-core/v2/
config. BuildConfig ({0x10656e3c8?,
0x13022c090?}, Оx0, 0x1?)
github.com/hiddify/hiddify-core/v2/
config/builder.go:70 +0x50
github.com/hiddify/hiddify-core/v2/
hcore.BuildConfig({0x10656e3c8,
0x13022c090}, 0x1302867e0)
github.com/hiddify/hiddify-core/v2/
hcore/buildconfighelper.go:40
```

This can occur in some environments where `StartService` is invoked
before internal state is fully initialized (e.g. app lifecycle edge cases).

### Solution

- Add a guard in `StartService` to check for nil `HiddifyOptions`
- Return a proper error instead of allowing a panic 

### Notes

This makes the startup logic more robust against invalid state without changing deeper configuration logic.