### PR TITLE
fix(v2/hcore): correct fmt usage and formatting issues

### DIFF
--- a/v2/hcore/tunnelservice/admin_service_commander.go
+++ b/v2/hcore/tunnelservice/admin_service_commander.go
@@ -17,7 +17,7 @@ import (
 const tunnelServicePort uint16 = 18020
 
 var (
-	tunnelServiceAddress = fmt.Sprint("127.0.0.1:%d", tunnelServicePort)
+	tunnelServiceAddress = fmt.Sprintf("127.0.0.1:%d", tunnelServicePort)
 	tunnelServiceRunning = false
 )
 

--- a/v2/hcore/tunnelservice/tunnel_platform_service.go
+++ b/v2/hcore/tunnelservice/tunnel_platform_service.go
@@ -159,13 +159,13 @@ func control(s service.Service, goArg string) (int, string) {
 	if err == nil {
 		out := fmt.Sprintf("Tunnel Service %sed Successfully.", goArg)
 		if dolog {
-			fmt.Printf(out)
+			fmt.Printf("%s", out)
 		}
 		return 0, out
 	} else {
 		out := fmt.Sprintf("Error: %v", err)
 		if dolog {
-			log.Printf(out)
+			log.Printf("%s", out)
 		}
 		return 2, out
 	}


### PR DESCRIPTION
### Problem

Some `fmt` usages may lead to incorrect formatting or runtime issues:

- `fmt.Sprint` used with formatting directives (`%d`)
- `fmt.Printf` called with non-constant format strings

### Solution

- Replace `fmt.Sprint` with `fmt.Sprintf` where needed
- Use explicit format strings in `fmt.Printf` / `log.Printf`

These changes improve correctness and avoid potential formatting bugs.