### PR TITLE
Change default TUN MTU from 9000 to 1492 (consumer-broadband-safe default, accommodates Ethernet and PPPoE)

### DIFF
--- a/v2/hiddifyoptions/hiddify_options.go
+++ b/v2/hiddifyoptions/hiddify_options.go
@@ -25,7 +25,7 @@ func DefaultHiddifyOptions() *HiddifyOptions {
 			TproxyPort:     12335,
 			RedirectPort:   12336,
 			DirectPort:     12337,
-			Mtu:            9000,
+			Mtu:            1492,
 			StrictRoute:    true,
 			TunStack:       "mixed",
 		},


### PR DESCRIPTION
## Summary

Change the hardcoded default `Mtu` in `DefaultHiddifyOptions().InboundOptions`
from **9000** (jumbo) to **1492**. 1492 is the effective path MTU on PPPoE
links (Ethernet 1500 minus the 8-byte PPPoE/PPP header per RFC 2516) and
also fits comfortably below standard Ethernet 1500 — so a single default
covers both common residential broadband path types without PMTUD
dependency.

## Why this is suboptimal today

`Mtu: 9000` advertises a jumbo-frame TUN interface to the OS. Jumbo frames
work on networks specifically configured for them (data center, some
enterprise LAN). The typical Hiddify user's network is consumer broadband with
standard 1500-byte path MTU, where a TUN interface advertising 9000 causes the
OS to write packets that don't fit the underlying path. Path MTU Discovery
exists for exactly this case but doesn't always work cleanly across NAT,
proxies, and home-network ICMP filtering — when it fails, packets are dropped
silently and the user sees "connected but nothing loads."

The symptom pattern in #1964 (and related threads) — system-proxy mode works,
VPN/TUN mode connects but pages hang — fits this profile. Reproduced
directly at the OP's exact default config on Ubuntu 24.04 LTS / Hiddify
v4.1.1: with `use-xray-core-when-possible: false` (Hiddify default,
sing-box backend) and a freshly-reimported VLESS profile (so `mtu: 9000`,
`strict-route: true`, `tun-implementation: gvisor` — all defaults), the
TUN tunnel comes up but `ping` to a remote IP succeeds while `curl` to web
URLs errors or stalls. That small-packets-work / large-packets-don't
divergence is the textbook PMTUD-blackhole signature: TUN MTU 9000 causes
the OS to announce MSS ~8960 to remote peers; response packets coming back
exceed the underlying ~1500-byte residential path MTU and are silently
dropped when ICMP "Fragmentation Needed" doesn't propagate cleanly.

## Why 1492 specifically

- **Covers both Ethernet and PPPoE residential paths.** Standard Ethernet
  path MTU is 1500; PPPoE adds 8 bytes of header (PPPoE 6 + PPP 2, per
  RFC 2516), reducing effective path MTU to 1492. A TUN default of 1500
  works on pure-Ethernet broadband but reintroduces a PMTUD dependency
  on PPPoE-based broadband (which is common in France, Germany, China,
  and legacy US/Russian residential). 1492 fits comfortably below both —
  no PMTUD needed for the typical home-broadband user, regardless of L2
  encapsulation choice.
- **Per-packet efficiency cost vs 1500 is ~0.5%** (8 bytes out of 1500).
  Trivial. The universal compatibility is worth it as a default.
- **Conservative compared to other tunnel tools.** WireGuard's `wg-quick`
  chooses interface MTU by auto-detecting the path MTU and subtracting
  80 bytes of protocol overhead, falling back to 1500 if discovery fails
  (effective default on Ethernet: 1420). See `wg-quick/linux.bash::set_mtu_up()`.
  Our proposal at 1492 is less conservative than WireGuard's 1420 but
  more conservative than naive 1500.
- **Doesn't preclude jumbo-frame users.** Users on networks that genuinely
  support 9000 can override — either via a future UI exposure of MTU, or
  via HiddifyCli's `-d <settings.json>` override (already works as of
  v4.1.1). The default just needs to serve the majority case.

## What this PR does NOT claim

- This is not asserted to be the sole root cause of every report in #1964.
  Several reporters there find their issue is fixed by running Hiddify as
  Administrator — that's a separate privilege/installation matter. This
  change addresses a different subset: cases where admin mode is already in
  effect but TUN-mode pages still don't load (the ping-works-curl-doesn't
  pattern of PMTUD-blackhole).
- It is not a claim that 1492 is optimal for every Hiddify user; it's a claim
  that 1492 is a safer default than 9000 for the majority Hiddify user.
- We have not isolated whether the MTU change alone is sufficient or whether
  other defaults (`strict-route: true`, `tun-implementation: gvisor`) also
  contribute to the symptom. See "Test plan" below for the empirical scope.

## Context — sing-box's own defaults

For reference (not used as the rationale for this PR), sing-box's TUN
inbound (`protocol/tun/inbound.go`) does NOT default to 9000 on all
platforms when `options.MTU == 0`. It branches:

- Network Extension (iOS/macOS): 4064
- Android: 9000 (note in source: "Some Android devices report ENOBUFS when
  using MTU 65535")
- Everything else (desktop Linux/Windows/macOS native): 65535

So Hiddify's hardcoded 9000 is already an explicit override of sing-box's
desktop default (65535 would be even worse on consumer broadband). The
choice of 9000 specifically matches sing-box's Android compatibility
fallback. This PR proposes a single cross-platform default of 1492, which
is below sing-box's ENOBUFS-prone 65535, below sing-box's Android-safe
9000, fits PPPoE residential paths exactly, and fits comfortably below
standard Ethernet 1500.

## Test plan

Verified manually on Ubuntu 24.04 LTS with Hiddify v4.1.1:

- **Direct GUI reproduction at the OP's default config:** with
  `use-xray-core-when-possible: false` (Hiddify default), VLESS profile
  freshly re-imported so all other Hiddify defaults applied (`mtu: 9000`,
  `strict-route: true`, `tun-implementation: gvisor`). With the TUN tunnel
  up: `ping` to a remote IP succeeds; `curl` to web URLs errors or stalls;
  browser pages either don't load or partial-load and hang. Small ICMP
  succeeds where larger HTTP responses fail — textbook PMTUD-blackhole
  signature consistent with the TUN MTU 9000 mismatch against the
  underlying ~1500-byte residential path MTU.
- **HiddifyCli plumbing check (proxy for the GUI's hardcoded MTU):** running
  `HiddifyCli run -c <vless-share-link> -d <settings.json>` where the
  settings JSON overrides `mtu: 1500` alongside `strict-route: false` and
  `tun-implementation: system` brings up `tun0` at MTU 1500 (`ip link show
  tun0`) and produces a working tunnel. This confirms the `mtu` field
  plumbs cleanly from user config → hiddify-core → libbox TUN inbound.
  (Plumbing test was at 1500; the proposed 1492 follows the same code path
  since the field is just a value passed to sing-box's TUN inbound options.)

What I have NOT done in this PR's test:

- **Isolation of which single setting is the actual fix.** The CLI test
  changed three defaults simultaneously (mtu, strict-route, tun-implementation),
  so we cannot claim that the MTU change alone is sufficient. The MTU is the
  strongest candidate based on the OP's config-dump signature and the
  PMTUD-blackhole symptom shape, but the other two may also matter. This PR
  is scoped to MTU on the grounds that it's the most likely contributing
  factor with the lowest-risk fix; other potentially-suboptimal defaults
  warrant separate triage.
- **End-to-end working-browser confirmation through the Hiddify GUI itself**
  at the proposed default. The Linux GUI has a separate privilege issue
  (Flutter binary RPATH conflicts with secure-exec when setcap is applied;
  requires `sudo hiddify`) that I worked around for testing via the CLI
  rather than the GUI. Other-platform testers should validate.
- **Packet-capture-level confirmation** that the specific failure on jumbo
  defaults is PMTUD-blackhole vs. some other failure path through the
  gvisor TUN + sing-box stack.

I'd appreciate validation from maintainers / other-platform testers before
merge.

## Risk

Minimal. Default-value change only; no logic change. Any user currently
relying on the jumbo default (network actually supports 9000) would
experience reduced TUN MTU, which means slightly lower per-packet
efficiency but no functional regression — the underlying TCP/UDP layers
adapt naturally. The reverse (1492 → 9000) would NOT have been safe in
this direction.

## Follow-up work (separate PR, not this one)

- Expose MTU as a user-settable field in `shared_preferences.json` and
  the desktop UI. Today it's only reachable via HiddifyCli `-d` override
  or by editing the LevelDB directly, neither of which is discoverable.

## Companion issue comment

Filed separately on `hiddify-app#1964` with the empirical reproduction
context that motivated this PR.
