### PR TITLE
test: point submodules at our forks for CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "hiddify-sing-box"]
 	path = hiddify-sing-box
-	url = https://github.com/hiddify/hiddify-sing-box
+	url = https://github.com/veto9292/hiddify-sing-box.git
 [submodule "ray2sing"]
 	path = ray2sing
-	url = git@github.com:hiddify/ray2sing.git
+	url = https://github.com/veto9292/ray2sing.git


### PR DESCRIPTION
- .gitmodules: hiddify-sing-box + ray2sing URLs → veto9292 forks
- hiddify-sing-box pointer: 3a1c923e → e3bef924 (testing-merge-base HEAD)
- ray2sing pointer unchanged (already at main HEAD caf5e9a)

No source changes; only submodule wiring.